### PR TITLE
NEP-LATEST Token Exchange Basic Extensions

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -77,7 +77,7 @@ First review [[nep-1.mediawiki|NEP-1]]. Then clone the repository and add your N
 |-
 | [[nep-Exchanges.mediawiki|LATEST]]
 | Token Exchange Basic Extensions
-| Michael Herman
+| Tyler Adams, luodanwg, tanyuan, Alan Fong, Michael Herman
 | Standard
 | Draft
 |-

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -76,7 +76,7 @@ First review [[nep-1.mediawiki|NEP-1]]. Then clone the repository and add your N
 | Final
 |-
 | [[nep-Exchanges.mediawiki|LATEST]]
-| Token Exchange Extensions
+| Token Exchange Basic Extensions
 | Michael Herman
 | Standard
 | Draft

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -71,7 +71,7 @@ First review [[nep-1.mediawiki|NEP-1]]. Then clone the repository and add your N
 |-
 | [[nep-10.mediawiki|10]]
 | Composite Smart Contracts
-| Michael Herman, Joe Stewart
+| Michael Herman
 | Standard
 | Final
 |-

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -75,6 +75,12 @@ First review [[nep-1.mediawiki|NEP-1]]. Then clone the repository and add your N
 | Standard
 | Final
 |-
+| [[nep-Exchanges.mediawiki|LATEST]]
+| Token Exchange Extensions
+| Michael Herman
+| Standard
+| Draft
+|-
 | 
 | Superconductive Exchange
 | 

--- a/nep-10.mediawiki
+++ b/nep-10.mediawiki
@@ -1,7 +1,7 @@
 <pre>
   NEP: 10
   Title: Composite Smart Contracts
-  Author: Michael Herman (mwherman@parallelspace.net) aka @mwherman2000, Joe Stewart (hal0x2328@splyse.tech) aka @hal0x2328
+  Author: Michael Herman (mwherman@parallelspace.net) aka @mwherman2000
   Type: Standard
   Status: Final
   Created: 2018-04-17

--- a/nep-Exchanges.mediawiki
+++ b/nep-Exchanges.mediawiki
@@ -1,0 +1,55 @@
+<pre>
+  NEP: LATEST
+  Title: Token Exchange Extensions
+  Author: Michael Herman (mwherman@parallelspace.net)
+  Type: Standard
+  Status: Draft
+  Created: 2018-07-21
+</pre>
+
+==Abstract==
+
+The NEP-LATEST Proposal defines three (3) additional methods design to extend the base level token
+functionality found in NEP-5.
+
+==Motivation==
+
+Blockchain exchanges require token smart contracts to implement additional methods to support
+the permissioned transfer of value from an originator to a receiver. NEP-LATEST provides definitions
+for these functions. 
+
+==Specification==
+
+In the method definitions below, we provide both the definitions of the functions as they are defined in the contract as well as the invoke parameters.
+
+All methods are required to be implemented to be compliant with this standard.
+
+NEP-LATEST is designed to be used in composition with NEP-5 and NEP-10.
+
+===Methods===
+
+====allowance====
+
+* Syntax: <code>public static BigInteger allowance(byte[] from, byte[] to)</code>
+
+* Remarks: "allowance" will return the amount of tokens that the '''to''' account can transfer from the '''from''' acount.
+
+====transferFrom====
+
+* Syntax: <code>public static bool transferFrom(byte[] originator, byte[] from, byte[] to, BigInteger amount)</code>
+
+* Remarks: "transferFrom" will transfer an '''amount''' from the '''from''' account to the '''to''' acount if the '''originator''' has been approved to transfer the requested '''amount'''.
+
+====approve====
+
+* Syntax: <code>public static bool approve(byte[] originator, byte[] to, BigInteger amount)</code>
+
+* Remarks: "approve" will approve the '''to''' account to transfer '''amount''' tokens from the '''originator''' acount. 
+
+===Events===
+
+None
+
+==Implementation==
+
+* TODO - Need an example that is compliant with ["NEP-5", "NEP-LATEST", "NEP-10"]

--- a/nep-Exchanges.mediawiki
+++ b/nep-Exchanges.mediawiki
@@ -9,7 +9,7 @@
 
 ==Abstract==
 
-The NEP-LATEST Proposal defines three (3) additional methods designed to extend the base level token
+The NEP-LATEST proposal defines three (3) additional methods designed to extend the base level token
 functionality found in NEP-5 to support the needs of third-party agents such as exchanges.  Specialized exchanges
 may require additional or different functionality.  They should create and submit additional NEP proposals that
 su[pport their needs.

--- a/nep-Exchanges.mediawiki
+++ b/nep-Exchanges.mediawiki
@@ -12,7 +12,7 @@
 The NEP-LATEST proposal defines three (3) additional methods designed to extend the base level token
 functionality found in NEP-5 to support the needs of third-party agents such as exchanges.  Specialized exchanges
 may require additional or different functionality.  They should create and submit additional NEP proposals that
-su[pport their needs.
+support their needs.
 
 ==Motivation==
 

--- a/nep-Exchanges.mediawiki
+++ b/nep-Exchanges.mediawiki
@@ -9,8 +9,10 @@
 
 ==Abstract==
 
-The NEP-LATEST Proposal defines three (3) additional methods design to extend the base level token
-functionality found in NEP-5.
+The NEP-LATEST Proposal defines three (3) additional methods designed to extend the base level token
+functionality found in NEP-5 to support the needs of third-party agents such as exchanges.  Specialized exchanges
+may require additional or different functionality.  They should create and submit additional NEP proposals that
+su[pport their needs.
 
 ==Motivation==
 

--- a/nep-Exchanges.mediawiki
+++ b/nep-Exchanges.mediawiki
@@ -1,7 +1,7 @@
 <pre>
   NEP: LATEST
   Title: Token Exchange Basic Extensions
-  Author: Michael Herman (mwherman@parallelspace.net)
+  Author: Tyler Adams <lllwvlvwlll@gmail.com>, luodanwg <luodan.wg@gmail.com>, tanyuan <tanyuan666@gmail.com>, Alan Fong <anfn@umich.edu>, Michael Herman (mwherman@parallelspace.net)
   Type: Standard
   Status: Draft
   Created: 2018-07-21

--- a/nep-Exchanges.mediawiki
+++ b/nep-Exchanges.mediawiki
@@ -32,19 +32,25 @@ NEP-LATEST is designed to be used in composition with NEP-5 and NEP-10.
 
 ====allowance====
 
-* Syntax: <code>public static BigInteger allowance(byte[] from, byte[] to)</code>
+<pre>
+public static BigInteger allowance(byte[] from, byte[] to)
+</pre>
 
 * Remarks: "allowance" will return the amount of tokens that the '''to''' account can transfer from the '''from''' acount.
 
 ====transferFrom====
 
-* Syntax: <code>public static bool transferFrom(byte[] originator, byte[] from, byte[] to, BigInteger amount)</code>
+<pre>
+public static bool transferFrom(byte[] originator, byte[] from, byte[] to, BigInteger amount)
+</pre>
 
 * Remarks: "transferFrom" will transfer an '''amount''' from the '''from''' account to the '''to''' acount if the '''originator''' has been approved to transfer the requested '''amount'''.
 
 ====approve====
 
-* Syntax: <code>public static bool approve(byte[] originator, byte[] to, BigInteger amount)</code>
+<pre>
+public static bool approve(byte[] originator, byte[] to, BigInteger amount)
+</pre>
 
 * Remarks: "approve" will approve the '''to''' account to transfer '''amount''' tokens from the '''originator''' acount. 
 
@@ -54,4 +60,4 @@ None
 
 ==Implementation==
 
-* TODO - Need an example that is compliant with ["NEP-5", "NEP-LATEST", "NEP-10"]
+* TODO - Need an example that is compliant with <code>["NEP-5", "NEP-LATEST", "NEP-10"]</code>.

--- a/nep-Exchanges.mediawiki
+++ b/nep-Exchanges.mediawiki
@@ -60,6 +60,11 @@ public static bool approve(byte[] originator, byte[] to, BigInteger amount)
 
 None
 
+===NEP-10 Compliance===
+
+NEP-LATEST compliant smart contracts are required to implement the <code>supportStandards</code> method using
+a pattern that is compatible with this example: https://github.com/neo-project/proposals/pull/60#issuecomment-407439745
+
 ==Implementation==
 
-* TODO - Need an example that is compliant with <code>["NEP-5", "NEP-LATEST", "NEP-10"]</code>.
+* TODO - Need an example that is compliant with <code>["NEP-5", "NEP-10", "NEP-LATEST"]</code>.

--- a/nep-Exchanges.mediawiki
+++ b/nep-Exchanges.mediawiki
@@ -1,6 +1,6 @@
 <pre>
   NEP: LATEST
-  Title: Token Exchange Extensions
+  Title: Token Exchange Basic Extensions
   Author: Michael Herman (mwherman@parallelspace.net)
   Type: Standard
   Status: Draft

--- a/nep-Exchanges.mediawiki
+++ b/nep-Exchanges.mediawiki
@@ -1,6 +1,6 @@
 <pre>
   NEP: LATEST
-  Title: Token Exchange Basic Extensions
+  Title: Token Extension: Third Party Transfers
   Author: Tyler Adams <lllwvlvwlll@gmail.com>, luodanwg <luodan.wg@gmail.com>, tanyuan <tanyuan666@gmail.com>, Alan Fong <anfn@umich.edu>, Michael Herman (mwherman@parallelspace.net)
   Type: Standard
   Status: Draft
@@ -10,8 +10,10 @@
 ==Abstract==
 
 The NEP-LATEST proposal defines three (3) additional methods designed to extend the base level token
-functionality found in NEP-5 to support the needs of third-party agents such as exchanges.  Specialized exchanges
-may require additional or different functionality.  They should create and submit additional NEP proposals that
+functionality found in NEP-5 to support the third-party transfer requirements of third-party agents 
+such as exchanges.  
+
+Specialized exchanges and other applications may require additional or different functionality.  They will need to create and submit additional NEP proposals that
 support their needs.
 
 ==Motivation==


### PR DESCRIPTION
==Abstract==

The NEP-LATEST proposal defines three (3) additional methods designed to extend the base level token
functionality found in NEP-5 to support the needs of third-party agents such as exchanges.  Specialized exchanges
may require additional or different functionality.  They should create and submit additional NEP proposals that support their needs