### PR TITLE
Interoperability enhancements to NEP5 (REVERT)

### DIFF
--- a/nep-5.mediawiki
+++ b/nep-5.mediawiki
@@ -15,11 +15,8 @@ The NEP-5 Proposal outlines a token standard for the NEO blockchain that will pr
 
 As the NEO blockchain scales, Smart Contract deployment and invocation will become increasingly important.  Without a standard interaction method, systems will be required to maintain a unique API for each contract, regardless of their similarity to other contracts.  Tokenized contracts present themselves as a prime example of this need because their basic operating mechanism is the same.  A standard method for interacting with these tokens relieves the entire ecosystem from maintaining a definition for basic operations that are required by every Smart Contract that employs a token.
 
-==Specification==
 
-In the method definitions below, we provide both the definitions of the functions as they are defined in the contract as well as the invoke parameters.
-
-===Methods===
+==Methods==
 
 ====totalSupply====
 
@@ -27,73 +24,148 @@ In the method definitions below, we provide both the definitions of the function
 public static BigInteger totalSupply()
 </pre>
 
+<b>Definition:</b> 
 Returns the total token supply deployed in the system.
 
+----
 ====name====
 
 <pre>
 public static string name()
 </pre>
 
+<b>Definition:</b> 
+
 Returns the name of the token. e.g. <code>"MyToken"</code>.
 
-This method MUST always return the same value every time it is invoked.
+<b>Remarks:</b>
 
+# This method <b>MUST</b> always return the same value every time it is invoked.
+
+----
 ====symbol====
 
 <pre>
 public static string symbol()
 </pre>
 
-Returns a short string symbol of the token managed in this contract. e.g. <code>"MYT"</code>. This symbol SHOULD be short (3-8 characters is recommended), with no whitespace characters or new-lines and SHOULD be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
+<b>Definition:</b>
 
-This method MUST always return the same value every time it is invoked.
+Returns a short string symbol of the token managed in this contract. e.g. <code>"MYT"</code>. 
 
+<b>Remarks:</b>
+
+# This symbol <b>SHOULD</b> be short (3-8 characters is recommended), with no whitespace characters or new-lines and <b>SHOULD</b> be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
+# This method <b>MUST</b> always return the same value every time it is invoked.
+
+----
 ====decimals====
 
 <pre>
 public static byte decimals()
 </pre>
 
+<b>Definition:</b>
+
 Returns the number of decimals used by the token - e.g. <code>8</code>, means to divide the token amount by <code>100,000,000</code> to get its user representation.
 
-This method MUST always return the same value every time it is invoked.
+<b>Remarks:</b>
 
+# This method <b>MUST</b> always return the same value every time it is invoked.
+
+----
 ====balanceOf====
 
 <pre>
-public static BigInteger balanceOf(byte[] account)
+public static BigInteger balanceOf(byte[] address)
 </pre>
 
-Returns the token balance of the <code>account</code>.
+<b>Definition:</b> 
 
-The parameter <code>account</code> SHOULD be a 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
+Returns the token balance of the <code>address</code>.
 
-If the <code>account</code> is an unused address, this method MUST return <code>0</code>.
+<b>Remarks:</b>
 
+# The parameter <code>address</code> <b>SHOULD</b> be a 20-byte address. If not, this method <b>SHOULD</b> <code>throw</code> an exception.
+# If the <code>address</code> is an unused address, this method <b>MUST</b> return <code>0</code>.
+
+----
 ====transfer====
 
 <pre>
 public static bool transfer(byte[] from, byte[] to, BigInteger amount)
 </pre>
 
-Transfers an <code>amount</code> of tokens from the <code>from</code> account to the <code>to</code> account.
+<b>Definition:</b> 
 
-The parameters <code>from</code> and <code>to</code> SHOULD be 20-byte addresses. If not, this method SHOULD <code>throw</code> an exception.
+Transfers an <code>amount</code> of tokens from the <code>from</code> address to the <code>to</code> address.
 
-The parameter <code>amount</code> MUST be greater than or equal to <code>0</code>. If not, this method SHOULD <code>throw</code> an exception.
+<b>Remarks:</b>
 
-The function MUST return <code>false</code> if the <code>from</code> account balance does not have enough tokens to spend.
+# The parameters <code>from</code> and <code>to</code> <b>SHOULD</b> be 20-byte addresses. If not, this method <b>SHOULD</b> <code>throw</code> an exception.
+# The parameter <code>amount</code> <b>MUST</b> be greater than or equal to <code>0</code>. If not, this method <b>SHOULD</b> <code>throw</code> an exception.
+# The method <b>MUST</b> return <code>false</code> if the <code>from</code> address balance does not have enough tokens to spend.
+# If the method succeeds, it <b>MUST</b> fire the <code>transfer</code> event, and <b>MUST</b> return <code>true</code>, even if the <code>amount</code> is <code>0</code>, or <code>from</code> and <code>to</code> are the same address.
+# The method <b>SHOULD</b> check whether the <code>from</code> address equals the caller contract hash. If so, the transfer <b>SHOULD</b> be processed; If not, the method <b>SHOULD</b> use the SYSCALL <code>Neo.Runtime.CheckWitness</code> to verify the transfer.
+# If the <code>to</code> address is a deployed contract, the method <b>SHOULD</b> check the <code>payable</code> flag of this contract to decide whether it should transfer the tokens to this contract.
+# If the transfer is not processed, the method <b>SHOULD</b> return <code>false</code>.
 
-If the method succeeds, it MUST fire the <code>transfer</code> event, and MUST return <code>true</code>, even if the <code>amount</code> is <code>0</code>, or <code>from</code> and <code>to</code> are the same address.
+----
+====approve====
 
-The function SHOULD check whether the <code>from</code> address equals the caller contract hash. If so, the transfer SHOULD be processed; If not, the function SHOULD use the SYSCALL <code>Neo.Runtime.CheckWitness</code> to verify the transfer.
+<pre>
+public static bool approve(byte[] originator, byte[] to, BigInteger amount)
+</pre>
 
-If the <code>to</code> address is a deployed contract, the function SHOULD check the <code>payable</code> flag of this contract to decide whether it should transfer the tokens to this contract.
+<b>Definition:</b> 
 
-If the transfer is not processed, the function SHOULD return <code>false</code>.
+Approves the <code>to</code> address to transfer <code>amount</code> tokens from the <code>originator</code> acount.
 
-===Events===
+<b>Remarks:</b>
+
+# The parameters <code>originator</code> and <code>to</code> <b>SHOULD</b> be 20-byte addresses.  If not, this method <b>SHOULD</b> throw an exception.
+# The parameter <code>amount</code> <b>MUST</b> be greater than or equal to <code>0</code>.  If not, this method <b>SHOULD</b> throw an exception.
+# The method <b>SHOULD</b> check whether the <code>originator</code> address equals the caller contract hash. If so, the allowance <b>SHOULD</b> be processed; If not, the method <b>SHOULD</b> use the SYSCALL Neo.Runtime.CheckWitness to verify the allowance.
+# If the <code>to</code> address is a deployed contract, the method <b>SHOULD</b> check the <code>payable</code> flag of this contract to decide wheter it should allow token transfer to this contract.
+
+----
+====allowance====
+
+<pre>
+public static BigInteger allowance(byte[] from, byte[] to)
+</pre>
+
+<b>Definition:</b>
+
+Returns the amount of tokens that the <code>to</code> address can transfer from the <code>from</code> acount.
+
+<b>Remarks:</b>
+
+# The parameters <code>from</code> and <code>to</code> <b>SHOULD</b> be a 20-byte address.  If not, this method <b>SHOULD</b> <code>throw</code> and exception.
+# If either <code>from</code> or <code>to</code> are unused, the method <b>MUST</b> return <code>0</code>
+
+----
+====transferFrom====
+
+<pre>
+public static bool transferFrom(byte[] originator, byte[] from, byte[] to, BigInteger amount)
+</pre>
+
+<b>Definition:</b>
+
+Transfers an <code>amount</code> from the <code>from</code> address to the <code>to</code> acount if the <code>originator</code> has been approved to transfer the requested <code>amount</code>.
+
+<b>Remarks:</b>
+
+# The parameters <code>originator</code>, <code>from</code>, and <code>to</code> <b>SHOULD</b> by 20-byte addresses.  If not, this method <b>SHOULD</b> <code>throw</code> and exception.
+# The <code>amount</code> parameter <b>MUST</b> be greater than or equal to <code>0</code>. If not, this method <b>SHOULD</b> <code>throw</code> and exception.
+# The method <b>MUST</b> return <code>false</code> if the <code>from</code> address does not have enough tokens to spend.
+# The method <b>MUST</b> return <code>false</code> if <code>amount</code> is less than either the <code>allowance</code> or the balance of the <code>from</code> address.
+# If the method succeeds, it <b>MUST</b> fire the transfer event, and <b>MUST</b> return true, even if the amount is 0, or from and to are the same address.
+# The method <b>SHOULD</b> check whether the <code>originator</code> address equals the caller contract hash. If so, the transfer <b>SHOULD</b> be processed; If not, the method <b>SHOULD</b> use the SYSCALL Neo.Runtime.CheckWitness to verify the transfer.
+# If the transfer is not processed, the method <b>SHOULD</b> return false.
+
+==Events==
 
 ====transfer====
 
@@ -101,14 +173,18 @@ If the transfer is not processed, the function SHOULD return <code>false</code>.
 public static event transfer(byte[] from, byte[] to, BigInteger amount)
 </pre>
 
-MUST trigger when tokens are transferred, including zero value transfers.
+<b>Definition:</b>
 
-A token contract which creates new tokens MUST trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
+An event which is emitted on a token transfer event.
 
-A token contract which burns tokens MUST trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
+<b>Remarks:</b>
 
-==Implementation==
+# <b>MUST</b> trigger when tokens are transferred, including zero value transfers.
+# A token contract which creates new tokens <b>MUST</b> trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
+# A token contract which burns tokens <b>MUST</b> trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
 
-*Woolong: https://github.com/lllwvlvwlll/Woolong
+==Implementations==
 
-*ICO Template: https://github.com/neo-project/examples/tree/master/ICO_Template
+* NEO ICO Template(C#): https://github.com/neo-project/examples/tree/master/ICO_Template
+* NEX ICO Template(Python): https://github.com/neonexchange/neo-ico-template
+* Moonlight ICO Template(C#): https://github.com/Moonlight-io/moonlight-ico-template

--- a/nep-5.mediawiki
+++ b/nep-5.mediawiki
@@ -1,7 +1,7 @@
 <pre>
   NEP: 5
   Title: Token Standard
-  Author: Tyler Adams <lllwvlvwlll@gmail.com>, luodanwg <luodan.wg@gmail.com>, tanyuan <tanyuan666@gmail.com>, Alan Fong <anfn@umich.edu>
+  Author: Tyler Adams <lllwvlvwlll@gmail.com>, luodanwg <luodan.wg@gmail.com>, tanyuan <tanyuan666@gmail.com>, Alan Fong <afong@cityofzion.io>
   Type: Standard
   Status: Final
   Created: 2017-08-10
@@ -119,7 +119,7 @@ public static bool approve(byte[] originator, byte[] to, BigInteger amount)
 
 <b>Definition:</b> 
 
-Approves the <code>to</code> address to transfer <code>amount</code> tokens from the <code>originator</code> acount.
+Approves the <code>to</code> address to transfer <code>amount</code> tokens from the <code>originator</code> account.
 
 <b>Remarks:</b>
 
@@ -137,12 +137,12 @@ public static BigInteger allowance(byte[] from, byte[] to)
 
 <b>Definition:</b>
 
-Returns the amount of tokens that the <code>to</code> address can transfer from the <code>from</code> acount.
+Returns the amount of tokens that the <code>to</code> address can transfer from the <code>from</code> account.
 
 <b>Remarks:</b>
 
 # The parameters <code>from</code> and <code>to</code> <b>SHOULD</b> be a 20-byte address.  If not, this method <b>SHOULD</b> <code>throw</code> and exception.
-# If either <code>from</code> or <code>to</code> are unused, the method <b>MUST</b> return <code>0</code>
+# If either <code>from</code> or <code>to</code> are unused, the method <b>MUST</b> return <code>0</code>.
 
 ----
 ====transferFrom====
@@ -153,7 +153,7 @@ public static bool transferFrom(byte[] originator, byte[] from, byte[] to, BigIn
 
 <b>Definition:</b>
 
-Transfers an <code>amount</code> from the <code>from</code> address to the <code>to</code> acount if the <code>originator</code> has been approved to transfer the requested <code>amount</code>.
+Transfers an <code>amount</code> from the <code>from</code> address to the <code>to</code> account if the <code>originator</code> has been approved to transfer the requested <code>amount</code>.
 
 <b>Remarks:</b>
 


### PR DESCRIPTION
## Context
The NEP-5 implementation was recently modified to remove all optional methods.  This pull request acknowledges the remarks that optional components should not be included alongside required components inside a standard(instead, these features should take advantage of NEP10).  

Instead, this proposal moves to make the optional methods required as part of the NEP5 standard as was the original intent. Considerations:

1) Most projects are already compliant with the change
2) The methods being added were part of the original standard and are required for the contract to be fully functional
3) Migration of these methods to a second standard via NEP10 will not resolve the issue.  Unless a developer has in-depth understanding of the ecosystem, they may overlook these methods unless they are defined in the actual token standard.
4) A single token standard is preferable over a new one in that it retains simplicity (developers are not required to understand minute differences between multiple token standards) at the expense of compliance of a few contracts which are already limited by the lack of support for these methods anyways.  Moving forward these methods will be critical for interoperability so support of NEP5 'basic' will not be relevant as a standard.

## Description
* Formatting changes for clarity
* Alignment of syntax (for example: functions => methods)
* Addition of the following methods as required:
  * approve
  * allowance
  * transferFrom