### PR TITLE
Remove authorship credit for myself from NEP-10

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -71,7 +71,7 @@ First review [[nep-1.mediawiki|NEP-1]]. Then clone the repository and add your N
 |-
 | [[nep-10.mediawiki|10]]
 | Composite Smart Contracts
-| Michael Herman, Joe Stewart
+| Michael Herman
 | Standard
 | Final
 |-

--- a/nep-10.mediawiki
+++ b/nep-10.mediawiki
@@ -1,7 +1,7 @@
 <pre>
   NEP: 10
   Title: Composite Smart Contracts
-  Author: Michael Herman (mwherman@parallelspace.net) aka @mwherman2000, Joe Stewart (hal0x2328@splyse.tech) aka @hal0x2328
+  Author: Michael Herman (mwherman@parallelspace.net) aka @mwherman2000
   Type: Standard
   Status: Final
   Created: 2018-04-17


### PR DESCRIPTION
I am withdrawing my name from the NEP-10 proposal and the proposals README file. The proposal itself is fine, but I no longer wish to be publicly credited for co-authorship of it.