### PR TITLE
Fix links in NEP6

### DIFF
--- a/nep-6.mediawiki
+++ b/nep-6.mediawiki
@@ -118,5 +118,5 @@ All old-format wallets should be able to be converted to this new JSON format ea
 
 ==Implementation==
 
-*neo-project/neo: https://github.com/neo-project/neo/blob/master/neo/Implementations/Wallets/NEP6/NEP6Wallet.cs
-*CityOfZion/neon-js: https://github.com/CityOfZion/neon-js/blob/master/src/wallet/Wallet.js
+*neo-project/neo: https://github.com/neo-project/neo/blob/master/neo/Wallets/NEP6/NEP6Wallet.cs 
+*CityOfZion/neon-js: https://github.com/CityOfZion/neon-js/blob/master/packages/neon-core/src/wallet/Wallet.ts 


### PR DESCRIPTION
The two links in NEP6 point to 404 pages, this PR fixes that.

I've separated this PR from #93 because #93's changes are unnecessary (they just improve wording) so it might not get merged.