### PR TITLE
Replace NEP-5 with NEP-17

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -75,11 +75,11 @@ First review [[nep-1.mediawiki|NEP-1]]. Then clone the repository and add your N
 | Standard
 | Accepted
 |-
-| [https://github.com/neo-project/proposals/pull/126 17]
+| [[nep-17.mediawiki|17]]
 | Token Standard
 | Erik Zhang
 | Standard
-| Accepted
+| Final
 |-
 | 
 | Dynamic Sharding

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -26,9 +26,9 @@ In the method definitions below, we provide both the definitions of the function
 
 <pre>
 {
-	"name": "symbol",
-	"parameters": [],
-	"returntype": "String"
+  "name": "symbol",
+  "parameters": [],
+  "returntype": "String"
 }
 </pre>
 
@@ -40,9 +40,9 @@ This method MUST always return the same value every time it is invoked.
 
 <pre>
 {
-	"name": "decimals",
-	"parameters": [],
-	"returntype": "Integer"
+  "name": "decimals",
+  "parameters": [],
+  "returntype": "Integer"
 }
 </pre>
 
@@ -54,9 +54,9 @@ This method MUST always return the same value every time it is invoked.
 
 <pre>
 {
-	"name": "totalSupply",
-	"parameters": [],
-	"returntype": "Integer"
+  "name": "totalSupply",
+  "parameters": [],
+  "returntype": "Integer"
 }
 </pre>
 
@@ -66,14 +66,14 @@ Returns the total token supply deployed in the system.
 
 <pre>
 {
-	"name": "balanceOf",
-	"parameters": [
-		{
-			"name": "account",
-			"type": "Hash160"
-		}
-	],
-	"returntype": "Integer"
+  "name": "balanceOf",
+  "parameters": [
+    {
+      "name": "account",
+      "type": "Hash160"
+    }
+  ],
+  "returntype": "Integer"
 }
 </pre>
 
@@ -87,22 +87,22 @@ If the <code>account</code> is an unused address, this method MUST return <code>
 
 <pre>
 {
-	"name": "transfer",
-	"parameters": [
-		{
-			"name": "from",
-			"type": "Hash160"
-		},
-		{
-			"name": "to",
-			"type": "Hash160"
-		},
-		{
-			"name": "amount",
-			"type": "Integer"
-		}
-	],
-	"returntype": "Boolean"
+  "name": "transfer",
+  "parameters": [
+    {
+      "name": "from",
+      "type": "Hash160"
+    },
+    {
+      "name": "to",
+      "type": "Hash160"
+    },
+    {
+      "name": "amount",
+      "type": "Integer"
+    }
+  ],
+  "returntype": "Boolean"
 }
 </pre>
 
@@ -125,14 +125,14 @@ If the receiver is a deployed contract, the function MUST call <code>onPayment</
 <pre>
 public static void onPayment(BigInteger amount)
 {
-	"name": "onPayment",
-	"parameters": [
-		{
-			"name": "amount",
-			"type": "Integer"
-		}
-	],
-	"returntype": "Void"
+  "name": "onPayment",
+  "parameters": [
+    {
+      "name": "amount",
+      "type": "Integer"
+    }
+  ],
+  "returntype": "Void"
 }
 </pre>
 
@@ -142,21 +142,21 @@ public static void onPayment(BigInteger amount)
 
 <pre>
 {
-	"name": "Transfer",
-	"parameters": [
-		{
-			"name": "from",
-			"type": "Hash160"
-		},
-		{
-			"name": "to",
-			"type": "Hash160"
-		},
-		{
-			"name": "amount",
-			"type": "Integer"
-		}
-	]
+  "name": "Transfer",
+  "parameters": [
+    {
+      "name": "from",
+      "type": "Hash160"
+    },
+    {
+      "name": "to",
+      "type": "Hash160"
+    },
+    {
+      "name": "amount",
+      "type": "Integer"
+    }
+  ]
 }
 </pre>
 

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -124,11 +124,11 @@ The function SHOULD check whether the <code>from</code> address equals the calle
 
 If the transfer is not processed, the function MUST return <code>false</code>.
 
-If the receiver is a deployed contract, the function MUST call <code>onPayment</code> method on receiver contract with the <code>data</code> parameter from <code>transfer</code> AFTER firing the <code>Transfer</code> event. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.
+If the receiver is a deployed contract, the function MUST call <code>onNEP17Payment</code> method on receiver contract with the <code>data</code> parameter from <code>transfer</code> AFTER firing the <code>Transfer</code> event. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.
 
 <pre>
 {
-  "name": "onPayment",
+  "name": "onNEP17Payment",
   "parameters": [
     {
       "name": "from",

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -82,7 +82,7 @@ The function SHOULD check whether the <code>from</code> address equals the calle
 
 If the transfer is not processed, the function MUST return <code>false</code>.
 
-The function MUST call <code>onPayment</code> method AFTER fire the <code>Transfer</code> event if the receiver is a deployed contract. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.
+If the receiver is a deployed contract, the function MUST call <code>onPayment</code> method on receiver contract AFTER firing the <code>Transfer</code> event. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.
 
 <pre>
 public static void onPayment(BigInteger amount)

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -96,7 +96,7 @@ public static void onPayment(BigInteger amount)
 public static event Transfer(byte[] from, byte[] to, BigInteger amount)
 </pre>
 
-MUST trigger when tokens are transferred, including zero value transfers.
+MUST trigger when tokens are transferred, including zero value transfers and self-transfers.
 
 A token contract which creates new tokens MUST trigger a <code>Transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
 

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -3,7 +3,7 @@
   Title: Token Standard
   Author: Erik Zhang <erik@neo.org>
   Type: Standard
-  Status: Accepted
+  Status: Final
   Created: 2020-11-12
   Replaces: 5
 </pre>

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -184,6 +184,6 @@ A token contract which burns tokens MUST trigger a <code>Transfer</code> event w
 
 ==Implementation==
 
-C#: https://github.com/neo-project/neo/pull/2024
+C#: https://github.com/neo-project/neo-devpack-dotnet/blob/master/src/Neo.SmartContract.Framework/Nep17Token.cs
 
 Python: https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/NEP17.py

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -3,7 +3,7 @@
   Title: Token Standard
   Author: Erik Zhang <erik@neo.org>
   Type: Standard
-  Status: Draft
+  Status: Accepted
   Created: 2020-11-12
   Replaces: 5
 </pre>

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -27,6 +27,7 @@ In the method definitions below, we provide both the definitions of the function
 <pre>
 {
   "name": "symbol",
+  "safe": true,
   "parameters": [],
   "returntype": "String"
 }
@@ -41,6 +42,7 @@ This method MUST always return the same value every time it is invoked.
 <pre>
 {
   "name": "decimals",
+  "safe": true,
   "parameters": [],
   "returntype": "Integer"
 }
@@ -55,6 +57,7 @@ This method MUST always return the same value every time it is invoked.
 <pre>
 {
   "name": "totalSupply",
+  "safe": true,
   "parameters": [],
   "returntype": "Integer"
 }
@@ -67,6 +70,7 @@ Returns the total token supply deployed in the system.
 <pre>
 {
   "name": "balanceOf",
+  "safe": true,
   "parameters": [
     {
       "name": "account",
@@ -88,6 +92,7 @@ If the <code>account</code> is an unused address, this method MUST return <code>
 <pre>
 {
   "name": "transfer",
+  "safe": false,
   "parameters": [
     {
       "name": "from",

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -80,8 +80,6 @@ If the method succeeds, it MUST fire the <code>transfer</code> event, and MUST r
 
 The function SHOULD check whether the <code>from</code> address equals the caller contract hash. If so, the transfer SHOULD be processed; If not, the function SHOULD use the SYSCALL <code>Neo.Runtime.CheckWitness</code> to verify the transfer.
 
-If the <code>to</code> address is a deployed contract, the function SHOULD check the <code>payable</code> flag of this contract to decide whether it should transfer the tokens to this contract.
-
 If the transfer is not processed, the function MUST return <code>false</code>.
 
 The function MUST call <code>onPayment</code> method AFTER fire the <code>Transfer</code> event if the receiver is a deployed contract. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -58,7 +58,7 @@ public static BigInteger balanceOf(byte[] account)
 
 Returns the token balance of the <code>account</code>.
 
-The parameter <code>account</code> SHOULD be a 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
+The parameter <code>account</code> MUST be a 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
 
 If the <code>account</code> is an unused address, this method MUST return <code>0</code>.
 
@@ -70,7 +70,7 @@ public static bool transfer(byte[] from, byte[] to, BigInteger amount)
 
 Transfers an <code>amount</code> of tokens from the <code>from</code> account to the <code>to</code> account.
 
-The parameters <code>from</code> and <code>to</code> SHOULD be 20-byte addresses. If not, this method SHOULD <code>throw</code> an exception.
+The parameters <code>from</code> and <code>to</code> MUST be 20-byte addresses. If not, this method SHOULD <code>throw</code> an exception.
 
 The parameter <code>amount</code> MUST be greater than or equal to <code>0</code>. If not, this method SHOULD <code>throw</code> an exception.
 
@@ -82,7 +82,7 @@ The function SHOULD check whether the <code>from</code> address equals the calle
 
 If the <code>to</code> address is a deployed contract, the function SHOULD check the <code>payable</code> flag of this contract to decide whether it should transfer the tokens to this contract.
 
-If the transfer is not processed, the function SHOULD return <code>false</code>.
+If the transfer is not processed, the function MUST return <code>false</code>.
 
 The function MUST call <code>onPayment</code> method AFTER fire the <code>Transfer</code> event if the receiver is a deployed contract. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.
 

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -25,7 +25,11 @@ In the method definitions below, we provide both the definitions of the function
 ====symbol====
 
 <pre>
-public static string symbol()
+{
+	"name": "symbol",
+	"parameters": [],
+	"returntype": "String"
+}
 </pre>
 
 Returns a short string representing symbol of the token managed in this contract. e.g. <code>"MYT"</code>. This string MUST be valid ASCII, MUST NOT contain whitespace or control characters, SHOULD be limited to uppercase Latin alphabet (i.e. the 26 letters used in English) and SHOULD be short (3-8 characters is recommended).
@@ -35,7 +39,11 @@ This method MUST always return the same value every time it is invoked.
 ====decimals====
 
 <pre>
-public static byte decimals()
+{
+	"name": "decimals",
+	"parameters": [],
+	"returntype": "Integer"
+}
 </pre>
 
 Returns the number of decimals used by the token - e.g. <code>8</code>, means to divide the token amount by <code>100,000,000</code> to get its user representation.
@@ -45,7 +53,11 @@ This method MUST always return the same value every time it is invoked.
 ====totalSupply====
 
 <pre>
-public static BigInteger totalSupply()
+{
+	"name": "totalSupply",
+	"parameters": [],
+	"returntype": "Integer"
+}
 </pre>
 
 Returns the total token supply deployed in the system.
@@ -53,7 +65,16 @@ Returns the total token supply deployed in the system.
 ====balanceOf====
 
 <pre>
-public static BigInteger balanceOf(byte[] account)
+{
+	"name": "balanceOf",
+	"parameters": [
+		{
+			"name": "account",
+			"type": "Hash160"
+		}
+	],
+	"returntype": "Integer"
+}
 </pre>
 
 Returns the token balance of the <code>account</code>.
@@ -65,7 +86,24 @@ If the <code>account</code> is an unused address, this method MUST return <code>
 ====transfer====
 
 <pre>
-public static bool transfer(byte[] from, byte[] to, BigInteger amount)
+{
+	"name": "transfer",
+	"parameters": [
+		{
+			"name": "from",
+			"type": "Hash160"
+		},
+		{
+			"name": "to",
+			"type": "Hash160"
+		},
+		{
+			"name": "amount",
+			"type": "Integer"
+		}
+	],
+	"returntype": "Boolean"
+}
 </pre>
 
 Transfers an <code>amount</code> of tokens from the <code>from</code> account to the <code>to</code> account.
@@ -86,6 +124,16 @@ If the receiver is a deployed contract, the function MUST call <code>onPayment</
 
 <pre>
 public static void onPayment(BigInteger amount)
+{
+	"name": "onPayment",
+	"parameters": [
+		{
+			"name": "amount",
+			"type": "Integer"
+		}
+	],
+	"returntype": "Void"
+}
 </pre>
 
 ===Events===
@@ -93,7 +141,23 @@ public static void onPayment(BigInteger amount)
 ====Transfer====
 
 <pre>
-public static event Transfer(byte[] from, byte[] to, BigInteger amount)
+{
+	"name": "Transfer",
+	"parameters": [
+		{
+			"name": "from",
+			"type": "Hash160"
+		},
+		{
+			"name": "to",
+			"type": "Hash160"
+		},
+		{
+			"name": "amount",
+			"type": "Integer"
+		}
+	]
+}
 </pre>
 
 MUST trigger when tokens are transferred, including zero value transfers and self-transfers.

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -1,15 +1,16 @@
 <pre>
-  NEP: 5
+  NEP: 17
   Title: Token Standard
-  Author: Tyler Adams <lllwvlvwlll@gmail.com>, luodanwg <luodan.wg@gmail.com>, tanyuan <tanyuan666@gmail.com>, Alan Fong <anfn@umich.edu>
+  Author: Erik Zhang <erik@neo.org>
   Type: Standard
-  Status: Final
-  Created: 2017-08-10
+  Status: Draft
+  Created: 2020-11-12
+  Replaces: 5
 </pre>
 
 ==Abstract==
 
-The NEP-5 Proposal outlines a token standard for the NEO blockchain that will provide systems with a generalized interaction mechanism for tokenized Smart Contracts.  This mechanic, along with the justification for each feature are defined.  A template and examples are also provided to enable the development community.
+This proposal outlines a token standard for the NEO blockchain that will provide systems with a generalized interaction mechanism for tokenized Smart Contracts.  This mechanic, along with the justification for each feature are defined.  A template and examples are also provided to enable the development community.
 
 ==Motivation==
 
@@ -20,24 +21,6 @@ As the NEO blockchain scales, Smart Contract deployment and invocation will beco
 In the method definitions below, we provide both the definitions of the functions as they are defined in the contract as well as the invoke parameters.
 
 ===Methods===
-
-====totalSupply====
-
-<pre>
-public static BigInteger totalSupply()
-</pre>
-
-Returns the total token supply deployed in the system.
-
-====name====
-
-<pre>
-public static string name()
-</pre>
-
-Returns the name of the token. e.g. <code>"MyToken"</code>.
-
-This method MUST always return the same value every time it is invoked.
 
 ====symbol====
 
@@ -58,6 +41,14 @@ public static byte decimals()
 Returns the number of decimals used by the token - e.g. <code>8</code>, means to divide the token amount by <code>100,000,000</code> to get its user representation.
 
 This method MUST always return the same value every time it is invoked.
+
+====totalSupply====
+
+<pre>
+public static BigInteger totalSupply()
+</pre>
+
+Returns the total token supply deployed in the system.
 
 ====balanceOf====
 
@@ -93,20 +84,26 @@ If the <code>to</code> address is a deployed contract, the function SHOULD check
 
 If the transfer is not processed, the function SHOULD return <code>false</code>.
 
-===Events===
-
-====transfer====
+The function MUST call <code>onPayment</code> method AFTER fire the <code>Transfer</code> event if the receiver is a deployed contract. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.
 
 <pre>
-public static event transfer(byte[] from, byte[] to, BigInteger amount)
+public static void onPayment(BigInteger amount)
+</pre>
+
+===Events===
+
+====Transfer====
+
+<pre>
+public static event Transfer(byte[] from, byte[] to, BigInteger amount)
 </pre>
 
 MUST trigger when tokens are transferred, including zero value transfers.
 
-A token contract which creates new tokens MUST trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
+A token contract which creates new tokens MUST trigger a <code>Transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
 
-A token contract which burns tokens MUST trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
+A token contract which burns tokens MUST trigger a <code>Transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
 
 ==Implementation==
 
-*neo-python: https://github.com/CityOfZion/neo-boa/blob/master/boa_test/example/demo/NEP5.py
+https://github.com/neo-project/neo/pull/2024

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -100,6 +100,10 @@ If the <code>account</code> is an unused address, this method MUST return <code>
     {
       "name": "amount",
       "type": "Integer"
+    },
+    {
+      "name": "data",
+      "type": "Any"
     }
   ],
   "returntype": "Boolean"
@@ -120,7 +124,7 @@ The function SHOULD check whether the <code>from</code> address equals the calle
 
 If the transfer is not processed, the function MUST return <code>false</code>.
 
-If the receiver is a deployed contract, the function MUST call <code>onPayment</code> method on receiver contract AFTER firing the <code>Transfer</code> event. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.
+If the receiver is a deployed contract, the function MUST call <code>onPayment</code> method on receiver contract with the <code>data</code> parameter from <code>transfer</code> AFTER firing the <code>Transfer</code> event. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.
 
 <pre>
 {
@@ -133,6 +137,10 @@ If the receiver is a deployed contract, the function MUST call <code>onPayment</
     {
       "name": "amount",
       "type": "Integer"
+    },
+    {
+      "name": "data",
+      "type": "Any"
     }
   ],
   "returntype": "Void"

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -128,6 +128,10 @@ public static void onPayment(BigInteger amount)
   "name": "onPayment",
   "parameters": [
     {
+      "name": "from",
+      "type": "Hash160"
+    },
+    {
       "name": "amount",
       "type": "Integer"
     }

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -179,4 +179,5 @@ A token contract which burns tokens MUST trigger a <code>Transfer</code> event w
 
 ==Implementation==
 
-https://github.com/neo-project/neo/pull/2024
+C#: https://github.com/neo-project/neo/pull/2024
+Python: https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/NEP17.py

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -114,7 +114,7 @@ The parameter <code>amount</code> MUST be greater than or equal to <code>0</code
 
 The function MUST return <code>false</code> if the <code>from</code> account balance does not have enough tokens to spend.
 
-If the method succeeds, it MUST fire the <code>transfer</code> event, and MUST return <code>true</code>, even if the <code>amount</code> is <code>0</code>, or <code>from</code> and <code>to</code> are the same address.
+If the method succeeds, it MUST fire the <code>Transfer</code> event, and MUST return <code>true</code>, even if the <code>amount</code> is <code>0</code>, or <code>from</code> and <code>to</code> are the same address.
 
 The function SHOULD check whether the <code>from</code> address equals the caller contract hash. If so, the transfer SHOULD be processed; If not, the function SHOULD use the SYSCALL <code>Neo.Runtime.CheckWitness</code> to verify the transfer.
 

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -180,4 +180,5 @@ A token contract which burns tokens MUST trigger a <code>Transfer</code> event w
 ==Implementation==
 
 C#: https://github.com/neo-project/neo/pull/2024
+
 Python: https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/NEP17.py

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -28,7 +28,7 @@ In the method definitions below, we provide both the definitions of the function
 public static string symbol()
 </pre>
 
-Returns a short string symbol of the token managed in this contract. e.g. <code>"MYT"</code>. This symbol SHOULD be short (3-8 characters is recommended), with no whitespace characters or new-lines and SHOULD be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
+Returns a short string representing symbol of the token managed in this contract. e.g. <code>"MYT"</code>. This string MUST be valid ASCII, MUST NOT contain whitespace or control characters, SHOULD be limited to uppercase Latin alphabet (i.e. the 26 letters used in English) and SHOULD be short (3-8 characters is recommended).
 
 This method MUST always return the same value every time it is invoked.
 

--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -123,7 +123,6 @@ If the transfer is not processed, the function MUST return <code>false</code>.
 If the receiver is a deployed contract, the function MUST call <code>onPayment</code> method on receiver contract AFTER firing the <code>Transfer</code> event. If the receiver doesn't want to receive this transfer it MUST call <code>ABORT</code>.
 
 <pre>
-public static void onPayment(BigInteger amount)
 {
   "name": "onPayment",
   "parameters": [

--- a/obsolete/nep-5.mediawiki
+++ b/obsolete/nep-5.mediawiki
@@ -1,0 +1,113 @@
+<pre>
+  NEP: 5
+  Title: Token Standard
+  Author: Tyler Adams <lllwvlvwlll@gmail.com>, luodanwg <luodan.wg@gmail.com>, tanyuan <tanyuan666@gmail.com>, Alan Fong <anfn@umich.edu>
+  Type: Standard
+  Status: Obsolete
+  Created: 2017-08-10
+  Superseded-By: 17
+</pre>
+
+==Abstract==
+
+The NEP-5 Proposal outlines a token standard for the NEO blockchain that will provide systems with a generalized interaction mechanism for tokenized Smart Contracts.  This mechanic, along with the justification for each feature are defined.  A template and examples are also provided to enable the development community.
+
+==Motivation==
+
+As the NEO blockchain scales, Smart Contract deployment and invocation will become increasingly important.  Without a standard interaction method, systems will be required to maintain a unique API for each contract, regardless of their similarity to other contracts.  Tokenized contracts present themselves as a prime example of this need because their basic operating mechanism is the same.  A standard method for interacting with these tokens relieves the entire ecosystem from maintaining a definition for basic operations that are required by every Smart Contract that employs a token.
+
+==Specification==
+
+In the method definitions below, we provide both the definitions of the functions as they are defined in the contract as well as the invoke parameters.
+
+===Methods===
+
+====totalSupply====
+
+<pre>
+public static BigInteger totalSupply()
+</pre>
+
+Returns the total token supply deployed in the system.
+
+====name====
+
+<pre>
+public static string name()
+</pre>
+
+Returns the name of the token. e.g. <code>"MyToken"</code>.
+
+This method MUST always return the same value every time it is invoked.
+
+====symbol====
+
+<pre>
+public static string symbol()
+</pre>
+
+Returns a short string symbol of the token managed in this contract. e.g. <code>"MYT"</code>. This symbol SHOULD be short (3-8 characters is recommended), with no whitespace characters or new-lines and SHOULD be limited to the uppercase latin alphabet (i.e. the 26 letters used in English).
+
+This method MUST always return the same value every time it is invoked.
+
+====decimals====
+
+<pre>
+public static byte decimals()
+</pre>
+
+Returns the number of decimals used by the token - e.g. <code>8</code>, means to divide the token amount by <code>100,000,000</code> to get its user representation.
+
+This method MUST always return the same value every time it is invoked.
+
+====balanceOf====
+
+<pre>
+public static BigInteger balanceOf(byte[] account)
+</pre>
+
+Returns the token balance of the <code>account</code>.
+
+The parameter <code>account</code> SHOULD be a 20-byte address. If not, this method SHOULD <code>throw</code> an exception.
+
+If the <code>account</code> is an unused address, this method MUST return <code>0</code>.
+
+====transfer====
+
+<pre>
+public static bool transfer(byte[] from, byte[] to, BigInteger amount)
+</pre>
+
+Transfers an <code>amount</code> of tokens from the <code>from</code> account to the <code>to</code> account.
+
+The parameters <code>from</code> and <code>to</code> SHOULD be 20-byte addresses. If not, this method SHOULD <code>throw</code> an exception.
+
+The parameter <code>amount</code> MUST be greater than or equal to <code>0</code>. If not, this method SHOULD <code>throw</code> an exception.
+
+The function MUST return <code>false</code> if the <code>from</code> account balance does not have enough tokens to spend.
+
+If the method succeeds, it MUST fire the <code>transfer</code> event, and MUST return <code>true</code>, even if the <code>amount</code> is <code>0</code>, or <code>from</code> and <code>to</code> are the same address.
+
+The function SHOULD check whether the <code>from</code> address equals the caller contract hash. If so, the transfer SHOULD be processed; If not, the function SHOULD use the SYSCALL <code>Neo.Runtime.CheckWitness</code> to verify the transfer.
+
+If the <code>to</code> address is a deployed contract, the function SHOULD check the <code>payable</code> flag of this contract to decide whether it should transfer the tokens to this contract.
+
+If the transfer is not processed, the function SHOULD return <code>false</code>.
+
+===Events===
+
+====transfer====
+
+<pre>
+public static event transfer(byte[] from, byte[] to, BigInteger amount)
+</pre>
+
+MUST trigger when tokens are transferred, including zero value transfers.
+
+A token contract which creates new tokens MUST trigger a <code>transfer</code> event with the <code>from</code> address set to <code>null</code> when tokens are created.
+
+A token contract which burns tokens MUST trigger a <code>transfer</code> event with the <code>to</code> address set to <code>null</code> when tokens are burned.
+
+==Implementation==
+
+*neo-python: https://github.com/CityOfZion/neo-boa/blob/master/boa_test/example/demo/NEP5.py


### PR DESCRIPTION
Differences from NEP-5:

1. Added `onPayment` call if the receiver is a deployed contract.
1. Removed `payable` check. It has been replaced by `onPayment`.
1. Removed `name` method, because it should be in manifest for all the contracts, not only for the token contracts.
1. Changed the `transfer` event to capitalize the first letter `Transfer`.