### PR TITLE
Don't check the caller in NEP17

### DIFF
--- a/nep-17.mediawiki
+++ b/nep-17.mediawiki
@@ -125,7 +125,7 @@ The function MUST return <code>false</code> if the <code>from</code> account bal
 
 If the method succeeds, it MUST fire the <code>Transfer</code> event, and MUST return <code>true</code>, even if the <code>amount</code> is <code>0</code>, or <code>from</code> and <code>to</code> are the same address.
 
-The function SHOULD check whether the <code>from</code> address equals the caller contract hash. If so, the transfer SHOULD be processed; If not, the function SHOULD use the SYSCALL <code>Neo.Runtime.CheckWitness</code> to verify the transfer.
+The function SHOULD verify the <code>from</code> address using the SYSCALL <code>Neo.Runtime.CheckWitness</code>.
 
 If the transfer is not processed, the function MUST return <code>false</code>.
 


### PR DESCRIPTION
This is not needed, and redundat because it's done during the syscall https://github.com/neo-project/neo/blob/736c346b9d8b1404f10023eeecb3a8e92ae0c542/src/neo/SmartContract/ApplicationEngine.Runtime.cs#L216