### PR TITLE
[Protocol] 3 seconds dbft consensus

### DIFF
--- a/nep-3-seconds.mediawiki
+++ b/nep-3-seconds.mediawiki
@@ -10,8 +10,11 @@
 ==Abstract==
 
 This NEP proposes two significant changes to the Neo N3 network parameters:
-1. Reducing the block time from 15 seconds to 3 seconds
-2. Reducing the GAS generation rate per block from 5 GAS to 1 GAS
+1. Enabling governance mechanism for block time adjustment via the Policy contract
+2. Preparing for future reduction of block time from 15 seconds to 3 seconds
+3. Preparing for future reduction of GAS generation rate per block from 5 GAS to 1 GAS
+
+The hardfork will introduce the governance methods while maintaining current values. After the hardfork, the Neo Council will be responsible for executing the parameter changes through the governance mechanism.
 
 ==Motivation==
 
@@ -23,20 +26,24 @@ The primary motivations for these changes are:
 ==Specification==
 
 ===Block Time Reduction===
-* Current value: 15 seconds
-* Proposed value: 3 seconds
+* Current value: 15 seconds (15000 milliseconds)
+* Initial value after hardfork: 15 seconds (15000 milliseconds)
+* Target value after council update: 3 seconds (3000 milliseconds)
 * Implementation: 
   * Move block time configuration from dBFT plugin to Policy native contract
+  * Initially maintain current block time at hardfork activation
   * Allow the council to configure block time through the Policy contract
-  * Consensus mechanism will read block time from the Policy contract
+  * Consensus mechanism will read block time from configuration for blocks up to and including the hardfork block
+  * Consensus mechanism will read block time from the Policy contract for blocks after the hardfork block
 
 ===GAS Generation Rate Reduction===
 * Current value: 5 GAS per block
-* Proposed value: 1 GAS per block
+* Initial value after hardfork: 5 GAS per block
+* Target value after council update: 1 GAS per block
 * Implementation: 
   * Retain the existing governance model where council controls GasPerBlock
-  * Council will need to adjust GasPerBlock separately after block time changes
-  * Coordination between the two changes will be managed through governance
+  * Council will adjust GasPerBlock after hardfork using existing mechanisms
+  * Coordination between block time and GAS per block changes will be managed through governance
 
 ===Policy Contract Enhancement===
 * New native method: `SetBlockGenTime(BigInteger milliseconds)`
@@ -66,7 +73,22 @@ The block time configuration methods will be added to the <code>PolicyContract</
             "type": "Integer"
         }
     ],
-    "returntype": "Boolean"
+    "returntype": "Boolean",
+    "events": [
+        {
+            "name": "BlockGenTimeChanged",
+            "parameters": [
+                {
+                    "name": "oldTime",
+                    "type": "Integer"
+                },
+                {
+                    "name": "newTime", 
+                    "type": "Integer"
+                }
+            ]
+        }
+    ]
 }
 </pre>
 
@@ -95,6 +117,9 @@ The <code>SetBlockGenTime</code> method MUST follow these rules:
    * MUST update the block time configuration
    * MUST take effect immediately after the transaction is executed
    * Consensus nodes MUST use the new block time for the next consensus round
+   * MUST emit an <code>Event</code> with the name "BlockGenTimeChanged" containing:
+     * The previous block generation time in milliseconds
+     * The new block generation time in milliseconds
 
 4. Return Value:
    * Returns true if the operation is successful
@@ -136,15 +161,18 @@ This permission model ensures that only the governance committee can modify crit
 * The hardfork will:
   * Add the new `SetBlockGenTime` and `GetBlockGenTime` methods to the Policy contract
   * Move block time configuration from consensus settings to Policy contract
-  * Initially set the default block time to 15 seconds (current value)
-  * After hardfork activation, the council will:
-    * Call the new method to set the block time to 3 seconds
-    * Adjust the GasPerBlock value separately to 1 GAS
+  * Initially set the default block time to 15 seconds (15000 milliseconds)
+  * The consensus module behavior will change:
+    * For blocks before and including the hardfork block (Ht), consensus time is read from configuration
+    * For blocks after the hardfork block (Ht+1 and beyond), consensus time is read from `GetBlockGenTime()`
+  * After hardfork activation, the council will be responsible for:
+    * Calling `SetBlockGenTime()` to adjust the block time to the target value
+    * Calling `SetGasPerBlock()` to adjust the GAS generation rate
   * Careful coordination will be needed to ensure economic balance
 
 ==Rationale==
 
-The reduction in block time from 15 to 3 seconds will:
+The reduction in block time from 15000 to 3000 milliseconds will:
 * Reduce transaction confirmation waiting times
 * Improve DApp responsiveness and user experience
 * Better compete with other high-performance blockchains
@@ -158,12 +186,12 @@ The reduction in GAS generation from 5 to 1 GAS per block will:
 
 * Block Time Configuration:
   * Current: Hardcoded in consensus settings (MillisecondsPerBlock: 15000)
-  * Proposed: Configurable via Policy contract with initial value of 15000
+  * After hardfork: Configurable via Policy contract with initial value of 15000 (15 seconds)
   * Target after council update: 3000 (3 seconds)
 * MaxTransactionsPerBlock: 512 => 256
 * GasPerBlock: 
   * Current: 5 GAS
-  * Proposed: Remains configurable by council via existing mechanisms
+  * After hardfork: Remains at 5 GAS until configured by council
   * Target after council update: 1 GAS
 * MaxValidUntilBlockIncrement: 100 => 500
 
@@ -191,7 +219,7 @@ The following scenarios should be tested:
 * Mitigation: Provide migration guidelines and testing framework
 
 3. Network Synchronization
-* Issue: Faster blocks may impact node sync speed since more block data will be generated.
+* Issue: Faster blocks may impact node sync speed
 * Mitigation: Implement enhanced sync protocols
 
 4. Governance Coordination
@@ -206,7 +234,9 @@ The following scenarios should be tested:
 
 The implementation requires modifications to:
 1. Policy native contract to add the new `SetBlockGenTime` and `GetBlockGenTime` methods
-2. Consensus mechanism to read block time from Policy contract
+2. Consensus mechanism to read block time:
+   * From configuration for blocks up to and including the hardfork block
+   * From Policy contract (`GetBlockGenTime()`) for blocks after the hardfork block
 3. Neo native contract to coordinate with the new timing system
 
 A phased implementation approach is recommended:

--- a/nep-3-seconds.mediawiki
+++ b/nep-3-seconds.mediawiki
@@ -25,22 +25,85 @@ The primary motivations for these changes are:
 ===Block Time Reduction===
 * Current value: 15 seconds
 * Proposed value: 3 seconds
-* Implementation: Modify the block time in dBFT plugin
+* Implementation: 
+  * Move block time configuration from dBFT plugin to Policy native contract
+  * Allow the council to configure block time through the Policy contract
+  * Consensus mechanism will read block time from the Policy contract
 
 ===GAS Generation Rate Reduction===
 * Current value: 5 GAS per block
 * Proposed value: 1 GAS per block
 * Implementation: 
-  * Modify the native Neo contract to include hardcoded upgrade logic
-  * At hardfork height, automatically apply 1/5 reduction to GasPerBlock
-  * This reduction remains in effect until council explicitly sets a new value
-  * Ensures stable GAS generation rate immediately after hardfork
-* Governance:
-  * Council retains ability to adjust GasPerBlock
-  * Any new value set by council will override the hardfork reduction
-  * Prevents potential GAS minting instability during the upgrade
+  * Retain the existing governance model where council controls GasPerBlock
+  * Add new native method in Policy contract to set block time and GAS generation simultaneously
+  * Provide a coordinated update mechanism to ensure economic stability
+
+===Policy Contract Enhancement===
+* New native method: `SetBlockTimeReward(BigInteger milliseconds, BigInteger datoshi)`
+  * Allows council to set both block time and GAS per block in a single operation
+  * Ensures atomic updates to both parameters
+  * Prevents inconsistency between block generation speed and GAS minting rate
+  * Parameters:
+    * `milliseconds`: The new block time in milliseconds
+    * `datoshi`: The new GAS generation rate per block in datoshi (1 GAS = 10^8 datoshi)
+
+===Native Contract Interface===
+
+The block time and GAS generation configuration method will be added to the <code>PolicyContract</code> native contract in hardfork <code>HF_Echidna</code> with the following interface:
+
+<pre>
+{
+    "name": "setBlockTimeReward",
+    "safe": false,
+    "parameters": [
+        {
+            "name": "milliseconds",
+            "type": "Integer"
+        },
+        {
+            "name": "datoshi",
+            "type": "Integer"
+        }
+    ],
+    "returntype": "Boolean"
+}
+</pre>
+
+===Method Specification===
+
+The <code>setBlockTimeReward</code> method MUST follow these rules:
+
+1. Permission Requirements:
+   * MUST only be callable by the Neo Council through a committee multi-signature transaction
+   * MUST fail if called by any other entity
+
+2. Input Requirements:
+   * <code>milliseconds</code> MUST be a positive integer representing block time in milliseconds
+   * <code>milliseconds</code> MUST be greater than or equal to 1000 (1 second)
+   * <code>datoshi</code> MUST be a non-negative integer representing GAS per block in datoshi units
+   * <code>datoshi</code> value of 100000000 represents 1 GAS
+
+3. Behavior:
+   * MUST atomically update both block time and GAS generation rate
+   * MUST take effect immediately after the transaction is executed
+   * Consensus nodes MUST use the new block time for the next consensus round
+   * GAS minting MUST use the new rate for the next block and all subsequent blocks
+
+4. Return Value:
+   * Returns true if the operation is successful
+   * Returns false if any validation fails
+
+5. Effect on Contracts:
+   * Contract executions MUST adapt to the new block time for all time-related calculations
+   * The consensus mechanism MUST read the block time from the Policy contract for each consensus round
 
 ===Hardfork Activation===
+* The hardfork will:
+  * Add the new `SetBlockTimeReward` method to the Policy contract
+  * Move block time configuration from consensus settings to Policy contract
+  * Initially set the default block time to 15 seconds (current value)
+  * After hardfork activation, the council will call the new method to set both parameters
+  * This ensures a coordinated transition to the new values
 
 ==Rationale==
 
@@ -56,13 +119,16 @@ The reduction in GAS generation from 5 to 1 GAS per block will:
 
 == Affected Configurations ==
 
-* MillisecondsPerBlock: 15000 => 3000
+* Block Time Configuration:
+  * Current: Hardcoded in consensus settings (MillisecondsPerBlock: 15000)
+  * Proposed: Configurable via Policy contract with initial value of 15000
+  * Target after council update: 3000 (3 seconds)
 * MaxTransactionsPerBlock: 512 => 256
 * GasPerBlock: 
   * Current: 5 GAS
-  * At hardfork: Automatically reduced to 1 GAS
-  * Post-hardfork: Configurable by council
-* MaxValidUntilBlockIncrement: 100 => 500?
+  * Proposed: Remains configurable by council via Policy contract
+  * Target after council update: 1 GAS
+* MaxValidUntilBlockIncrement: 100 => 500
 
 ==Backwards Compatibility==
 
@@ -91,17 +157,26 @@ The following scenarios should be tested:
 * Issue: Faster blocks may impact node sync speed
 * Mitigation: Implement enhanced sync protocols
 
+4. Governance Coordination
+* Issue: Mismatch between block time and GAS generation rate changes
+* Mitigation: The new atomic `SetBlockTimeReward` method ensures consistent updates
+
+5. Contract Dependency on Block Time
+* Issue: Contracts relying on block time for time-related calculations will be affected
+* Mitigation: Documentation and tools to help developers update affected contracts
+
 ==Implementation==
 
 The implementation requires modifications to:
-1. Core consensus mechanism
-2. Native Neo contract
-3. dBFT plugin
+1. Policy native contract to add the new `SetBlockTimeReward` method
+2. Consensus mechanism to read block time from Policy contract
+3. Neo native contract to coordinate with the new timing system
 
 A phased implementation approach is recommended:
 1. TestNet deployment and testing (2 weeks)
 2. MainNet deployment preparation (1 month)
 3. Hard fork coordination and execution
+4. Council governance action to call `SetBlockTimeReward(3000, 100000000)` after hardfork
 
 ==Reference Implementation==
 

--- a/nep-3-seconds.mediawiki
+++ b/nep-3-seconds.mediawiki
@@ -39,7 +39,7 @@ The primary motivations for these changes are:
   * Coordination between the two changes will be managed through governance
 
 ===Policy Contract Enhancement===
-* New native method: `SetBlockTime(BigInteger milliseconds)`
+* New native method: `SetBlockGenTime(BigInteger milliseconds)`
   * Allows council to set block time through the Policy contract
   * Parameters:
     * `milliseconds`: The new block time in milliseconds

--- a/nep-3-seconds.mediawiki
+++ b/nep-3-seconds.mediawiki
@@ -41,16 +41,24 @@ The primary motivations for these changes are:
 ===Policy Contract Enhancement===
 * New native method: `SetBlockGenTime(BigInteger milliseconds)`
   * Allows council to set block time through the Policy contract
+  * **Permission restricted**: Can only be called by the Neo Council
+  * **Safe**: False (requires verification)
   * Parameters:
     * `milliseconds`: The new block time in milliseconds
+* New native method: `GetBlockGenTime()`
+  * Returns the current block generation time
+  * **Permission**: Can be called by any user or contract
+  * **Safe**: True (read-only operation)
+  * Returns:
+    * A BigInteger representing the current block time in milliseconds
 
 ===Native Contract Interface===
 
-The block time configuration method will be added to the <code>PolicyContract</code> native contract in hardfork <code>Echidna</code> with the following interface:
+The block time configuration methods will be added to the <code>PolicyContract</code> native contract in hardfork <code>Echidna</code> with the following interfaces:
 
 <pre>
 {
-    "name": "setBlockTime",
+    "name": "SetBlockGenTime",
     "safe": false,
     "parameters": [
         {
@@ -62,13 +70,22 @@ The block time configuration method will be added to the <code>PolicyContract</c
 }
 </pre>
 
+<pre>
+{
+    "name": "GetBlockGenTime",
+    "safe": true,
+    "parameters": [],
+    "returntype": "Integer"
+}
+</pre>
+
 ===Method Specification===
 
-The <code>setBlockTime</code> method MUST follow these rules:
+The <code>SetBlockGenTime</code> method MUST follow these rules:
 
 1. Permission Requirements:
    * MUST only be callable by the Neo Council through a committee multi-signature transaction
-   * MUST fail if called by any other entity
+   * MUST fail with "Access denied" error if called by any other entity
 
 2. Input Requirements:
    * <code>milliseconds</code> MUST be a positive integer representing block time in milliseconds
@@ -83,13 +100,41 @@ The <code>setBlockTime</code> method MUST follow these rules:
    * Returns true if the operation is successful
    * Returns false if any validation fails
 
+The <code>GetBlockGenTime</code> method MUST follow these rules:
+
+1. Permission Requirements:
+   * Can be called by any entity (contracts, users, or applications)
+   * MUST be marked as "safe": true in the contract manifest to enable read-only access
+
+2. Behavior:
+   * MUST return the current block generation time in milliseconds
+
+3. Return Value:
+   * Returns an integer representing the current block time in milliseconds
+
 5. Effect on Contracts:
    * Contract executions MUST adapt to the new block time for all time-related calculations
    * The consensus mechanism MUST read the block time from the Policy contract for each consensus round
 
+===Permission Enforcement===
+
+The Policy contract MUST implement strict permission enforcement:
+
+1. For `SetBlockGenTime`:
+   * The method MUST verify the caller is the Neo Council committee
+   * Implementation MUST use the CheckCommittee verification pattern
+   * Any unauthorized calls MUST be rejected with appropriate error codes
+
+2. For `GetBlockGenTime`:
+   * No permission checks required
+   * Must be implemented as a read-only operation
+   * Cannot modify blockchain state
+
+This permission model ensures that only the governance committee can modify critical consensus parameters while providing transparent access to current settings.
+
 ===Hardfork Activation===
 * The hardfork will:
-  * Add the new `SetBlockTime` method to the Policy contract
+  * Add the new `SetBlockGenTime` and `GetBlockGenTime` methods to the Policy contract
   * Move block time configuration from consensus settings to Policy contract
   * Initially set the default block time to 15 seconds (current value)
   * After hardfork activation, the council will:
@@ -160,7 +205,7 @@ The following scenarios should be tested:
 ==Implementation==
 
 The implementation requires modifications to:
-1. Policy native contract to add the new `SetBlockTime` method
+1. Policy native contract to add the new `SetBlockGenTime` and `GetBlockGenTime` methods
 2. Consensus mechanism to read block time from Policy contract
 3. Neo native contract to coordinate with the new timing system
 
@@ -169,7 +214,7 @@ A phased implementation approach is recommended:
 2. MainNet deployment preparation (2 weeks)
 3. Hard fork coordination and execution
 4. Council governance actions after hardfork:
-   * Call `SetBlockTime(3000)` to set new block time
+   * Call `SetBlockGenTime(3000)` to set new block time
    * Adjust GasPerBlock to 1 GAS using existing governance mechanisms
 
 ==Reference Implementation==

--- a/nep-3-seconds.mediawiki
+++ b/nep-3-seconds.mediawiki
@@ -83,15 +83,11 @@ The following scenarios should be tested:
 * Issue: Faster block times may increase network overhead
 * Mitigation: Implement improved network optimization and node requirements
 
-2. Node Requirements
-* Issue: Higher hardware requirements for validators
-* Mitigation: Phase implementation to allow gradual node upgrades
-
-3. Smart Contract Timing
+2. Smart Contract Timing
 * Issue: Some contracts may assume 15-second blocks
 * Mitigation: Provide migration guidelines and testing framework
 
-4. Network Synchronization
+3. Network Synchronization
 * Issue: Faster blocks may impact node sync speed
 * Mitigation: Implement enhanced sync protocols
 

--- a/nep-3-seconds.mediawiki
+++ b/nep-3-seconds.mediawiki
@@ -191,7 +191,7 @@ The following scenarios should be tested:
 * Mitigation: Provide migration guidelines and testing framework
 
 3. Network Synchronization
-* Issue: Faster blocks may impact node sync speed
+* Issue: Faster blocks may impact node sync speed since more block data will be generated.
 * Mitigation: Implement enhanced sync protocols
 
 4. Governance Coordination

--- a/nep-3-seconds.mediawiki
+++ b/nep-3-seconds.mediawiki
@@ -1,6 +1,6 @@
 <NEP: xxx>
   Title: Reduce Block Time and Gas Generation Rate
-  Author: Jimmy Liao <vvvincentvan@gmail.com>, Vitor Nazário Coelho <vncoelho@gmail.com>
+  Author: Jimmy Liao <vvvincentvan@gmail.com>, Vitor Nazário Coelho <vncoelho@gmail.com>,  Fernando Díaz Toledano <shargon@gmail.com>, Roman Khimov <roman@nspcc.ru>, Christopher Schuchardt <chris.schuchardt@neo.events> 
   Type: Standard
   Status: Draft
   Created: 2025-02-11
@@ -35,33 +35,26 @@ The primary motivations for these changes are:
 * Proposed value: 1 GAS per block
 * Implementation: 
   * Retain the existing governance model where council controls GasPerBlock
-  * Add new native method in Policy contract to set block time and GAS generation simultaneously
-  * Provide a coordinated update mechanism to ensure economic stability
+  * Council will need to adjust GasPerBlock separately after block time changes
+  * Coordination between the two changes will be managed through governance
 
 ===Policy Contract Enhancement===
-* New native method: `SetBlockTimeReward(BigInteger milliseconds, BigInteger datoshi)`
-  * Allows council to set both block time and GAS per block in a single operation
-  * Ensures atomic updates to both parameters
-  * Prevents inconsistency between block generation speed and GAS minting rate
+* New native method: `SetBlockTime(BigInteger milliseconds)`
+  * Allows council to set block time through the Policy contract
   * Parameters:
     * `milliseconds`: The new block time in milliseconds
-    * `datoshi`: The new GAS generation rate per block in datoshi (1 GAS = 10^8 datoshi)
 
 ===Native Contract Interface===
 
-The block time and GAS generation configuration method will be added to the <code>PolicyContract</code> native contract in hardfork <code>HF_Echidna</code> with the following interface:
+The block time configuration method will be added to the <code>PolicyContract</code> native contract in hardfork <code>Echidna</code> with the following interface:
 
 <pre>
 {
-    "name": "setBlockTimeReward",
+    "name": "setBlockTime",
     "safe": false,
     "parameters": [
         {
             "name": "milliseconds",
-            "type": "Integer"
-        },
-        {
-            "name": "datoshi",
             "type": "Integer"
         }
     ],
@@ -71,7 +64,7 @@ The block time and GAS generation configuration method will be added to the <cod
 
 ===Method Specification===
 
-The <code>setBlockTimeReward</code> method MUST follow these rules:
+The <code>setBlockTime</code> method MUST follow these rules:
 
 1. Permission Requirements:
    * MUST only be callable by the Neo Council through a committee multi-signature transaction
@@ -80,14 +73,11 @@ The <code>setBlockTimeReward</code> method MUST follow these rules:
 2. Input Requirements:
    * <code>milliseconds</code> MUST be a positive integer representing block time in milliseconds
    * <code>milliseconds</code> MUST be greater than or equal to 1000 (1 second)
-   * <code>datoshi</code> MUST be a non-negative integer representing GAS per block in datoshi units
-   * <code>datoshi</code> value of 100000000 represents 1 GAS
 
 3. Behavior:
-   * MUST atomically update both block time and GAS generation rate
+   * MUST update the block time configuration
    * MUST take effect immediately after the transaction is executed
    * Consensus nodes MUST use the new block time for the next consensus round
-   * GAS minting MUST use the new rate for the next block and all subsequent blocks
 
 4. Return Value:
    * Returns true if the operation is successful
@@ -99,11 +89,13 @@ The <code>setBlockTimeReward</code> method MUST follow these rules:
 
 ===Hardfork Activation===
 * The hardfork will:
-  * Add the new `SetBlockTimeReward` method to the Policy contract
+  * Add the new `SetBlockTime` method to the Policy contract
   * Move block time configuration from consensus settings to Policy contract
   * Initially set the default block time to 15 seconds (current value)
-  * After hardfork activation, the council will call the new method to set both parameters
-  * This ensures a coordinated transition to the new values
+  * After hardfork activation, the council will:
+    * Call the new method to set the block time to 3 seconds
+    * Adjust the GasPerBlock value separately to 1 GAS
+  * Careful coordination will be needed to ensure economic balance
 
 ==Rationale==
 
@@ -126,7 +118,7 @@ The reduction in GAS generation from 5 to 1 GAS per block will:
 * MaxTransactionsPerBlock: 512 => 256
 * GasPerBlock: 
   * Current: 5 GAS
-  * Proposed: Remains configurable by council via Policy contract
+  * Proposed: Remains configurable by council via existing mechanisms
   * Target after council update: 1 GAS
 * MaxValidUntilBlockIncrement: 100 => 500
 
@@ -158,8 +150,8 @@ The following scenarios should be tested:
 * Mitigation: Implement enhanced sync protocols
 
 4. Governance Coordination
-* Issue: Mismatch between block time and GAS generation rate changes
-* Mitigation: The new atomic `SetBlockTimeReward` method ensures consistent updates
+* Issue: Non-atomic updates between block time and GAS generation rate
+* Mitigation: Careful governance coordination to adjust both settings in close succession
 
 5. Contract Dependency on Block Time
 * Issue: Contracts relying on block time for time-related calculations will be affected
@@ -168,7 +160,7 @@ The following scenarios should be tested:
 ==Implementation==
 
 The implementation requires modifications to:
-1. Policy native contract to add the new `SetBlockTimeReward` method
+1. Policy native contract to add the new `SetBlockTime` method
 2. Consensus mechanism to read block time from Policy contract
 3. Neo native contract to coordinate with the new timing system
 
@@ -176,7 +168,9 @@ A phased implementation approach is recommended:
 1. TestNet deployment and testing (2 weeks)
 2. MainNet deployment preparation (1 month)
 3. Hard fork coordination and execution
-4. Council governance action to call `SetBlockTimeReward(3000, 100000000)` after hardfork
+4. Council governance actions after hardfork:
+   * Call `SetBlockTime(3000)` to set new block time
+   * Adjust GasPerBlock to 1 GAS using existing governance mechanisms
 
 ==Reference Implementation==
 

--- a/nep-3-seconds.mediawiki
+++ b/nep-3-seconds.mediawiki
@@ -166,7 +166,7 @@ The implementation requires modifications to:
 
 A phased implementation approach is recommended:
 1. TestNet deployment and testing (2 weeks)
-2. MainNet deployment preparation (1 month)
+2. MainNet deployment preparation (2 weeks)
 3. Hard fork coordination and execution
 4. Council governance actions after hardfork:
    * Call `SetBlockTime(3000)` to set new block time

--- a/nep-3-seconds.mediawiki
+++ b/nep-3-seconds.mediawiki
@@ -1,0 +1,112 @@
+<NEP: xxx>
+  Title: Reduce Block Time and Gas Generation Rate
+  Author: Jimmy Liao <vvvincentvan@gmail.com>, Vitor Nazário Coelho <vncoelho@gmail.com>
+  Type: Standard
+  Status: Draft
+  Created: 2025-02-11
+  Replaces: N/A
+  Hardfork: Echidna
+
+==Abstract==
+
+This NEP proposes two significant changes to the Neo N3 network parameters:
+1. Reducing the block time from 15 seconds to 3 seconds
+2. Reducing the GAS generation rate per block from 5 GAS to 1 GAS
+
+==Motivation==
+
+The primary motivations for these changes are:
+1. Improve transaction throughput and user experience
+2. Maintain a stable GAS/NEO ratio in the ecosystem
+3. Better compete with other high-performance blockchain platforms
+
+==Specification==
+
+===Block Time Reduction===
+* Current value: 15 seconds
+* Proposed value: 3 seconds
+* Implementation: Modify the block time in dBFT plugin
+
+===GAS Generation Rate Reduction===
+* Current value: 5 GAS per block
+* Proposed value: 1 GAS per block
+* Implementation: 
+  * Modify the native Neo contract to include hardcoded upgrade logic
+  * At hardfork height, automatically apply 1/5 reduction to GasPerBlock
+  * This reduction remains in effect until council explicitly sets a new value
+  * Ensures stable GAS generation rate immediately after hardfork
+* Governance:
+  * Council retains ability to adjust GasPerBlock
+  * Any new value set by council will override the hardfork reduction
+  * Prevents potential GAS minting instability during the upgrade
+
+===Hardfork Activation===
+
+==Rationale==
+
+The reduction in block time from 15 to 3 seconds will:
+* Reduce transaction confirmation waiting times
+* Improve DApp responsiveness and user experience
+* Better compete with other high-performance blockchains
+
+The reduction in GAS generation from 5 to 1 GAS per block will:
+* Maintain economic balance despite increased block production
+* Preserve the intended tokenomics of the Neo ecosystem
+* Prevent potential GAS oversupply and value dilution
+
+== Affected Configurations ==
+
+* MillisecondsPerBlock: 15000 => 3000
+* MaxTransactionsPerBlock: 512 => 256
+* GasPerBlock: 
+  * Current: 5 GAS
+  * At hardfork: Automatically reduced to 1 GAS
+  * Post-hardfork: Configurable by council
+* MaxValidUntilBlockIncrement: 100 => 500?
+
+==Backwards Compatibility==
+
+This change requires a hard fork as it modifies fundamental network parameters. All nodes must upgrade to maintain network consensus.
+
+==Test Cases==
+
+The following scenarios should be tested:
+1. Network stability under 3-second block times
+2. Transaction processing under high load
+3. Node synchronization with faster blocks
+4. GAS generation and distribution accuracy
+5. Smart contract execution under new timing constraints
+
+==Potential Issues and Mitigations==
+
+1. Network Stability
+* Issue: Faster block times may increase network overhead
+* Mitigation: Implement improved network optimization and node requirements
+
+2. Node Requirements
+* Issue: Higher hardware requirements for validators
+* Mitigation: Phase implementation to allow gradual node upgrades
+
+3. Smart Contract Timing
+* Issue: Some contracts may assume 15-second blocks
+* Mitigation: Provide migration guidelines and testing framework
+
+4. Network Synchronization
+* Issue: Faster blocks may impact node sync speed
+* Mitigation: Implement enhanced sync protocols
+
+==Implementation==
+
+The implementation requires modifications to:
+1. Core consensus mechanism
+2. Native Neo contract
+3. dBFT plugin
+
+A phased implementation approach is recommended:
+1. TestNet deployment and testing (2 weeks)
+2. MainNet deployment preparation (1 month)
+3. Hard fork coordination and execution
+
+==Reference Implementation==
+
+CSharp implementation: https://github.com/neo-project/neo/pull/3622


### PR DESCRIPTION
This pr tries to formalize our so called 3-seconds consensus. 

It requires hardfork and:

- reduce the block time from 15 seconds to 3 seconds
- reduce the gasperblock from 5 GAS to 1 GAS

Affected Configurations:

* MillisecondsPerBlock: 15000 => 3000
* MaxTransactionsPerBlock: 512 => 256
* GasPerBlock: 
  * Current: 5 GAS
  * At hardfork: Automatically reduced to 1 GAS
  * Post-hardfork: Configurable by council
* MaxValidUntilBlockIncrement: 100 => 500?