### PR TITLE
[Standard] Fixed/Dynamic Gas Contract Method Pricing

### DIFF
--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -37,9 +37,9 @@ then will read the <code>JSON</code> string to see if the method exists. If the 
    - If the amount does exist. Than that unit amount will than be deducted.
    - Amount can't be negative. If is negative than this entry is ignored.
 1. Receiver Address
-   - If receiver doesn't exist. Than the contract itself must have the <code>onNEP17Payment</code> method, must support NEP17 and accept GAS.
-   - If reciever does exist. Than the reciever address will be used. The reciever address can be a NEP17 contract. However the contract must accept GAS.
-   - If an error occurs for any reason the gas is then burned and added as an VM fee as used GAS.
+   - If receiver doesn't exist. Then the contract itself must have the <code>onNEP17Payment</code> method, must support NEP17 and accept GAS.
+   - If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract must accept GAS.
+   - If an error occurs for any reason the gas is than burned.
    - If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
 
 ==JSON==

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -33,7 +33,7 @@ then will read the <code>JSON</code> string to see if the method exists. If the 
    - Method can't start with underscores <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
    - Methods <code>verify</code> and <code>onNEP17Payment</code> will be ignored.
 1. Amount
-   - If the amount doesn't exist. Then the small unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
+   - If the amount doesn't exist. Then the smallest unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
    - If the amount does exist. Than that unit amount will than be deducted.
    - Amount can't be negative. If is negative than this entry is ignored.
 1. Receiver Address

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -17,22 +17,10 @@ Now contract owners, such as a exchange may want a way to get a little gas for s
 
 ==Specification==
 
-The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current NEO platforms.
-
 ==Rationale==
-
-The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
-
-The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.
 
 ==Backwards Compatibility==
 
-All NEPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The NEP must explain how the author proposes to deal with these incompatibilities. NEP submissions without a sufficient backwards compatibility treatise may be rejected outright.
-
 ==Test Cases==
 
-Test cases for an implementation are mandatory for NEPs that are affecting consensus changes. Other NEPs can choose to include links to test cases if applicable.
-
 ==Implementation==
-
-The implementations must be completed before any NEP is given status "Final", but it need not be completed before the NEP is accepted. It is better to finish the specification and rationale first and reach consensus on it before writing code.

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -34,10 +34,10 @@ then will read the <code>JSON</code> string to see if the method exists. If the 
    - Methods <code>verify</code> and <code>onNEP17Payment</code> will be ignored.
 1. Amount
    - If the amount doesn't exist. Then the small unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
-   - If the amount does exist. Than that unit amount will than be deducted from.
+   - If the amount does exist. Than that unit amount will than be deducted.
    - Amount can't be negative. If is negative than this entry is ignored.
 1. Receiver Address
-   - If receiver doesn't exist. Than the contract itself must have the <code>onNEP17Payment</code> method and must support NEP17 and accept GAS.
+   - If receiver doesn't exist. Than the contract itself must have the <code>onNEP17Payment</code> method, must support NEP17 and accept GAS.
    - If reciever does exist. Than the reciever address will be used. The reciever address can be a NEP17 contract. However the contract must accept GAS.
    - If an error occurs for any reason the gas is then burned and added as an VM fee as used GAS.
    - If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -27,19 +27,19 @@ contain all the meta data for each method name, amount and/or receiver address.
 When syscall <code>System.Contract.Call</code> calls a method within the contract it checks contract storage for <code>0xfe</code> prefix. If it exists
 then will read the <code>JSON</code> string to see if the method exists. If the method does exist than will follow the following.
 
-1. Method
-  * Method must exist within the contract's manifest.
-  * If method doesn't exist within the manifest than entry is ignored.
-  * Method can not start with a underscore <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
-  * Methods <code>verify</code>, <code>onNEP11Payment</code> and <code>onNEP17Payment</code> will be ignored.
-2. Amount
-  * If the amount doesn't exist. Then the smallest unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
-  * If the amount does exist. Than that unit amount will than be deducted.
-  * Amount can not be negative. If is negative than this entry is ignored.
-3. Receiver Address
-  * If receiver doesn't exist. Then the contract itself **SHOULD** have the <code>onNEP17Payment</code> method and **SHOULD** support NEP17 and accept GAS.
-  * If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract **SHOULD** accept GAS.
-  * If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
+* Method
+** Method must exist within the contract's manifest.
+** If method doesn't exist within the manifest than entry is ignored.
+** Method can not start with a underscore <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
+** Methods <code>verify</code>, <code>onNEP11Payment</code> and <code>onNEP17Payment</code> will be ignored.
+* Amount
+** If the amount doesn't exist. Then the smallest unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
+** If the amount does exist. Than that unit amount will than be deducted.
+** Amount can not be negative. If is negative than this entry is ignored.
+* Receiver Address
+** If receiver doesn't exist. Then the contract itself **SHOULD** have the <code>onNEP17Payment</code> method and **SHOULD** support NEP17 and accept GAS.
+** If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract **SHOULD** accept GAS.
+** If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
 
 ===JSON Storage===
 

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -1,6 +1,6 @@
 <pre>
   NEP: 33
-  Title: Fixed/Dynamic Non-native Contract Method Pricing
+  Title: Fixed/Dynamic Gas Contract Method Pricing
   Author: Christopher Schuchardt <cschuchardt88@gmail.com>
   Type: Standard
   Status: Draft
@@ -16,7 +16,7 @@ pricing for methods within their contract then sendings the funds to the contrac
 
 Now contract owners, such as a exchange may want a way to get a little gas for sending funds to external wallets. This would allow the contract to have
 one or several methods to have a <code>fixed</code> price, taking a bit of GAS from transactioner for calling the a method (Much like an opcode price works).
-For example, a LP token maybe want you to pay a gas for withdrawing funds. Reason most LP/Fund contracts do this to pay for the LP contract pool's 
+For example, a LP token maybe want you to pay gas for withdrawing funds. Reason most LP/Fund contracts do this to pay for the LP contract pool's 
 transaction fees for adjusting prices and other things.
 
 ==Specification==
@@ -30,19 +30,21 @@ then will read the <code>JSON</code> string to see if the method exists. If the 
 1. Method
    - Method must exist within the contract's manifest.
    - If method doesn't exist within the manifest than entry is ignored.
-   - Method can't start with underscores <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
-   - Methods <code>verify</code> and <code>onNEP17Payment</code> will be ignored.
+   - Method can not start with a underscore <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
+   - Methods <code>verify</code>, <code>onNEP11Payment</code> and <code>onNEP17Payment</code> will be ignored.
 1. Amount
    - If the amount doesn't exist. Then the smallest unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
    - If the amount does exist. Than that unit amount will than be deducted.
-   - Amount can't be negative. If is negative than this entry is ignored.
+   - Amount can not be negative. If is negative than this entry is ignored.
 1. Receiver Address
-   - If receiver doesn't exist. Then the contract itself must have the <code>onNEP17Payment</code> method, must support NEP17 and accept GAS.
-   - If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract must accept GAS.
-   - If an error occurs for any reason the gas is than burned.
+   - If receiver doesn't exist. Then the contract itself **SHOULD** have the <code>onNEP17Payment</code> method and **SHOULD** support NEP17 and accept GAS.
+   - If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract **SHOULD** accept GAS.
    - If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
 
-==JSON==
+===JSON Storage===
+
+The <code>JSON</code> _below_ is an example of the storage value at <code>0xfe</code>.
+
 <pre>
 [
   {
@@ -53,6 +55,44 @@ then will read the <code>JSON</code> string to see if the method exists. If the 
 ]
 </pre>
 
-==Storage==
+===Contract Methods===
+
+Other contract creators may want to know the price of a contract's methods. To do so there is a method <code>required</code> to get price of any method
+within the contract. This method is called <code>GetMethodPrice</code>. This method returns either a <code>JSON</code> array or object depending upon
+how you call the method. The method has one argument (_parameter_). This argument is of type <code>String</code>. The argument takes in the name of the
+method you want the price for. This method name **MUST** exist in the contract's manifest (_if it does not than the method does not exist within the contract_).
+Passing in <code>null</code> tells the method to return a <code>JSON</code> Array of all the contract's methods that has fees associated with them. Otherwise
+passing in a method name will return **ONLY** that entry. 
+
+===JSON Method Entry===
+
+====JSON Array====
+
+Calling <code>GetMethodPrice</code> with <code>null</code>.
+<pre>
+[
+  {
+    "name": "MyMethod1"                                       // method name
+    "amount": 1                                               // in Datoshi
+    "receive": "0x0000000000000000000000000000000000000000"   // Receiver address in ScriptHash format
+  },
+  {
+    "name": "MyMethod2"                                       // method name
+    "amount": 100000000                                       // in Datoshi
+    "receive": "0x0000000000000000000000000000000000000000"   // Receiver address in ScriptHash format
+  }
+]
+</pre>
+
+====JSON Object====
+
+Calling <code>GetMethodPrice</code> with <code>MyMethod2</code>.
+<pre>
+{
+  "name": "MyMethod2"                                       // method name
+  "amount": 100000000                                       // in Datoshi
+  "receive": "0x0000000000000000000000000000000000000000"   // Receiver address in ScriptHash format
+}
+</pre>
 
 ==Implementation==

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -1,0 +1,38 @@
+<pre>
+  NEP: 33
+  Title: Fixed/Dynamic Non-native Contract Method Pricing
+  Author: Christopher Schuchardt <cschuchardt88@gmail.com>
+  Type: Standard
+  Status: Draft
+  Created: 2025-08-30
+</pre>
+
+==Abstract==
+
+One may want to charge a fee for calling one of their contract methods. Allowing non-native contracts to have <code>fixed</code> or <code>dynamic</code> pricing for methods within their contract then sendings the funds to the contract itself.
+
+==Motivation==
+
+Now contract owners, such as a exchange may want a way to get a little gas for sending funds to external wallets. This would allow the contract to have one or several methods to have a <code>fixed</code> price, taking a bit of GAS from transactioner for calling the a method (Much like an opcode price works). For example, a LP token maybe want you to pay a gas for withdrawing funds. Reason most LP/Fund contracts do this to pay for the LP contract pool's transaction fees for adjusting prices and other things.
+
+==Specification==
+
+The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current NEO platforms.
+
+==Rationale==
+
+The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
+
+The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.
+
+==Backwards Compatibility==
+
+All NEPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The NEP must explain how the author proposes to deal with these incompatibilities. NEP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+==Test Cases==
+
+Test cases for an implementation are mandatory for NEPs that are affecting consensus changes. Other NEPs can choose to include links to test cases if applicable.
+
+==Implementation==
+
+The implementations must be completed before any NEP is given status "Final", but it need not be completed before the NEP is accepted. It is better to finish the specification and rationale first and reach consensus on it before writing code.

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -33,17 +33,17 @@ then will read the <code>JSON</code> string to see if the method exists. If the 
 ** Method can not start with a underscore <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
 ** Methods <code>verify</code>, <code>onNEP11Payment</code> and <code>onNEP17Payment</code> will be ignored.
 * Amount
-** If the amount doesn't exist. Then the smallest unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
+** If the amount doesn't exist. Then the smallest unit of GAS is used (Datoshi). For example: GAS's small unit in Datoshi <code>0.00000001</code>
 ** If the amount does exist. Than that unit amount will than be deducted.
 ** Amount can not be negative. If is negative than this entry is ignored.
 * Receiver Address
-** If receiver doesn't exist. Then the contract itself **SHOULD** have the <code>onNEP17Payment</code> method and **SHOULD** support NEP17 and accept GAS.
-** If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract **SHOULD** accept GAS.
+** If receiver doesn't exist. Then the contract itself SHOULD have the <code>onNEP17Payment</code> method and SHOULD support NEP17 and accept GAS.
+** If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract SHOULD accept GAS.
 ** If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
 
 ===JSON Storage===
 
-The <code>JSON</code> _below_ is an example of the storage value at <code>0xfe</code>.
+The <code>JSON</code> below is an example of the storage value at <code>0xfe</code>.
 
 <pre>
 [
@@ -59,10 +59,10 @@ The <code>JSON</code> _below_ is an example of the storage value at <code>0xfe</
 
 Other contract creators may want to know the price of a contract's methods. To do so there is a method <code>required</code> to get price of any method
 within the contract. This method is called <code>GetMethodPrice</code>. This method returns either a <code>JSON</code> array or object depending upon
-how you call the method. The method has one argument (_parameter_). This argument is of type <code>String</code>. The argument takes in the name of the
-method you want the price for. This method name **MUST** exist in the contract's manifest (_if it does not than the method does not exist within the contract_).
+how you call the method. The method has one argument (parameter). This argument is of type <code>String</code>. The argument takes in the name of the
+method you want the price for. This method name MUST exist in the contract's manifest (if it does not than the method does not exist within the contract).
 Passing in <code>null</code> tells the method to return a <code>JSON</code> Array of all the contract's methods that has fees associated with them. Otherwise
-passing in a method name will return **ONLY** that entry. 
+passing in a method name will return ONLY that entry. 
 
 ===JSON Method Entry===
 

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -9,18 +9,50 @@
 
 ==Abstract==
 
-One may want to charge a fee for calling one of their contract methods. Allowing non-native contracts to have <code>fixed</code> or <code>dynamic</code> pricing for methods within their contract then sendings the funds to the contract itself.
+One may want to charge a fee for calling one of their contract methods. Allowing non-native contracts to have <code>fixed</code> or <code>dynamic</code>
+pricing for methods within their contract then sendings the funds to the contract itself.
 
 ==Motivation==
 
-Now contract owners, such as a exchange may want a way to get a little gas for sending funds to external wallets. This would allow the contract to have one or several methods to have a <code>fixed</code> price, taking a bit of GAS from transactioner for calling the a method (Much like an opcode price works). For example, a LP token maybe want you to pay a gas for withdrawing funds. Reason most LP/Fund contracts do this to pay for the LP contract pool's transaction fees for adjusting prices and other things.
+Now contract owners, such as a exchange may want a way to get a little gas for sending funds to external wallets. This would allow the contract to have
+one or several methods to have a <code>fixed</code> price, taking a bit of GAS from transactioner for calling the a method (Much like an opcode price works).
+For example, a LP token maybe want you to pay a gas for withdrawing funds. Reason most LP/Fund contracts do this to pay for the LP contract pool's 
+transaction fees for adjusting prices and other things.
 
 ==Specification==
 
-==Rationale==
+Contract will have a <code>JSON</code> string in their storage at prefix <code>0xfe</code>. At this storage location the <code>JSON</code> string will
+contain all the meta data for each method name, amount and/or receiver address. 
 
-==Backwards Compatibility==
+When syscall <code>System.Contract.Call</code> calls a method within the contract it checks contract storage for <code>0xfe</code> prefix. If it exists
+then will read the <code>JSON</code> string to see if the method exists. If the method does exist than will follow the following.
 
-==Test Cases==
+1. Method
+   - Method must exist within the contract's manifest.
+   - If method doesn't exist within the manifest than entry is ignored.
+   - Method can't start with underscores <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
+   - Methods <code>verify</code> and <code>onNEP17Payment</code> will be ignored.
+1. Amount
+   - If the amount doesn't exist. Then the small unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
+   - If the amount does exist. Than that unit amount will than be deducted from.
+   - Amount can't be negative. If is negative than this entry is ignored.
+1. Receiver Address
+   - If receiver doesn't exist. Than the contract itself must have the <code>onNEP17Payment</code> method and must support NEP17 and accept GAS.
+   - If reciever does exist. Than the reciever address will be used. The reciever address can be a NEP17 contract. However the contract must accept GAS.
+   - If an error occurs for any reason the gas is then burned and added as an VM fee as used GAS.
+   - If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
+
+==JSON==
+<pre>
+[
+  {
+    "name": "MyMethod"                                        // method name
+    "amount": 1                                               // in Datoshi
+    "receive": "0x0000000000000000000000000000000000000000"   // Receiver address in ScriptHash format
+  }
+]
+</pre>
+
+==Storage==
 
 ==Implementation==

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -28,18 +28,18 @@ When syscall <code>System.Contract.Call</code> calls a method within the contrac
 then will read the <code>JSON</code> string to see if the method exists. If the method does exist than will follow the following.
 
 1. Method
-   - Method must exist within the contract's manifest.
-   - If method doesn't exist within the manifest than entry is ignored.
-   - Method can not start with a underscore <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
-   - Methods <code>verify</code>, <code>onNEP11Payment</code> and <code>onNEP17Payment</code> will be ignored.
+  - Method must exist within the contract's manifest.
+  - If method doesn't exist within the manifest than entry is ignored.
+  - Method can not start with a underscore <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
+  - Methods <code>verify</code>, <code>onNEP11Payment</code> and <code>onNEP17Payment</code> will be ignored.
 1. Amount
-   - If the amount doesn't exist. Then the smallest unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
-   - If the amount does exist. Than that unit amount will than be deducted.
-   - Amount can not be negative. If is negative than this entry is ignored.
+  - If the amount doesn't exist. Then the smallest unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
+  - If the amount does exist. Than that unit amount will than be deducted.
+  - Amount can not be negative. If is negative than this entry is ignored.
 1. Receiver Address
-   - If receiver doesn't exist. Then the contract itself **SHOULD** have the <code>onNEP17Payment</code> method and **SHOULD** support NEP17 and accept GAS.
-   - If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract **SHOULD** accept GAS.
-   - If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
+  - If receiver doesn't exist. Then the contract itself **SHOULD** have the <code>onNEP17Payment</code> method and **SHOULD** support NEP17 and accept GAS.
+  - If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract **SHOULD** accept GAS.
+  - If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
 
 ===JSON Storage===
 

--- a/nep-33.mediawiki
+++ b/nep-33.mediawiki
@@ -28,18 +28,18 @@ When syscall <code>System.Contract.Call</code> calls a method within the contrac
 then will read the <code>JSON</code> string to see if the method exists. If the method does exist than will follow the following.
 
 1. Method
-  - Method must exist within the contract's manifest.
-  - If method doesn't exist within the manifest than entry is ignored.
-  - Method can not start with a underscore <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
-  - Methods <code>verify</code>, <code>onNEP11Payment</code> and <code>onNEP17Payment</code> will be ignored.
-1. Amount
-  - If the amount doesn't exist. Then the smallest unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
-  - If the amount does exist. Than that unit amount will than be deducted.
-  - Amount can not be negative. If is negative than this entry is ignored.
-1. Receiver Address
-  - If receiver doesn't exist. Then the contract itself **SHOULD** have the <code>onNEP17Payment</code> method and **SHOULD** support NEP17 and accept GAS.
-  - If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract **SHOULD** accept GAS.
-  - If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
+  * Method must exist within the contract's manifest.
+  * If method doesn't exist within the manifest than entry is ignored.
+  * Method can not start with a underscore <code>_</code>. This limits malicious activity. For example if you were to require a fee for <code>_initialize</code>.
+  * Methods <code>verify</code>, <code>onNEP11Payment</code> and <code>onNEP17Payment</code> will be ignored.
+2. Amount
+  * If the amount doesn't exist. Then the smallest unit of GAS is used (_Datoshi_). _For example: GAS's small unit in Datoshi <code>0.00000001</code>_
+  * If the amount does exist. Than that unit amount will than be deducted.
+  * Amount can not be negative. If is negative than this entry is ignored.
+3. Receiver Address
+  * If receiver doesn't exist. Then the contract itself **SHOULD** have the <code>onNEP17Payment</code> method and **SHOULD** support NEP17 and accept GAS.
+  * If reciever does exist. Then the reciever address will be used. The reciever address can be a NEP17 contract. However that contract **SHOULD** accept GAS.
+  * If <code>0x0000000000000000000000000000000000000000</code> is used the amount is burnned no matter what.
 
 ===JSON Storage===
 


### PR DESCRIPTION
Now contract owners, such as a exchange may want a way to get a little gas for sending funds to external wallets. This would allow the contract to have one or several methods to have a fixed price, taking a bit of GAS from transactioner for calling the a method (Much like an opcode price works). For example, a LP token maybe want you to pay gas for withdrawing funds. Reason most LP/Fund contracts do this to pay for the LP contract pool's transaction fees for adjusting prices and other things.